### PR TITLE
Reduce objects copy

### DIFF
--- a/src/Helpers/UdpServer.cpp
+++ b/src/Helpers/UdpServer.cpp
@@ -37,7 +37,7 @@ UdpServer::~UdpServer()
 void UdpServer::startReceive()
 {
 	_keepRunning = true;
-	_receiverThread = std::thread([=]
+	_receiverThread = std::thread([=]()
 		{
 			char buffer[BUFFER_SIZE];
 			sockaddr_in senderEndPoint;
@@ -47,6 +47,7 @@ void UdpServer::startReceive()
 			while (_keepRunning)
 			{
 				recvfrom(_sockfd, buffer, BUFFER_SIZE, 0, reinterpret_cast<struct sockaddr*>(&senderEndPoint), &len);
+				if (!_keepRunning) return;
 				_onNewMessageEvent(std::move(buffer), senderEndPoint);
 			}
 		});

--- a/src/Helpers/UdpServer.hpp
+++ b/src/Helpers/UdpServer.hpp
@@ -12,7 +12,7 @@ public:
 	using OnNewMessageEvent = std::function<void(std::string, sockaddr_in)>;
 	static constexpr int BUFFER_SIZE = 2048;
 
-	UdpServer(std::string ip ,int port, OnNewMessageEvent event);
+	UdpServer(std::string ip, int port, OnNewMessageEvent event);
 	~UdpServer();
 
 	void startReceive();

--- a/src/SIP/RequestsHandler.cpp
+++ b/src/SIP/RequestsHandler.cpp
@@ -4,13 +4,9 @@
 #include "SipSdpMessage.hpp"
 #include "IDGen.hpp"
 
-RequestsHandler::RequestsHandler(std::string serverIp, int serverPort, std::unordered_map<std::string, std::shared_ptr<Session>>& sessions,
-	std::unordered_map<std::string, std::shared_ptr<SipClient>>& clients,
-	std::function<void(std::shared_ptr<SipClient>)> onNewClientEvent, std::function<void(std::shared_ptr<SipClient>)> onUnregisterEvent, OnHandledEvent onHandledEvent) :
+RequestsHandler::RequestsHandler(std::string serverIp, int serverPort,
+	OnHandledEvent onHandledEvent) :
 	_serverIp(std::move(serverIp)), _serverPort(serverPort),
-	_sessions(sessions), _clients(clients),
-	_onNewClient(onNewClientEvent),
-	_onUnregister(onUnregisterEvent),
 	_onHandled(onHandledEvent)
 {
 	initHandlers();
@@ -38,10 +34,6 @@ void RequestsHandler::handle(std::shared_ptr<SipMessage> request)
 	{
 		_handlers[request->getType()](std::move(request));
 	}
-	else
-	{
-		std::cout << request->getType() << " not found in map handlers" << std::endl;
-	}
 }
 
 std::optional<std::shared_ptr<Session>> RequestsHandler::getSession(const std::string& callID)
@@ -61,7 +53,7 @@ void RequestsHandler::OnRegister(std::shared_ptr<SipMessage> data)
 	if (!isUnregister)
 	{
 		auto newClient = std::make_shared<SipClient>(data->getFromNumber(), data->getSource());
-		_onNewClient(std::move(newClient));
+		registerClient(std::move(newClient));
 	}
 
 	auto response = data;
@@ -69,12 +61,12 @@ void RequestsHandler::OnRegister(std::shared_ptr<SipMessage> data)
 	response->setVia(data->getVia() + ";received=" + _serverIp);
 	response->setTo(data->getTo() + ";tag=" + IDGen::GenerateID(9));
 	response->setContact("Contact: <sip:" + data->getFromNumber() + "@" + _serverIp + ":" + std::to_string(_serverPort) + ";transport=UDP>");
-	_onHandled(response->getFromNumber(), response);
+	endHandle(response->getFromNumber(), response);
 
 	if (isUnregister)
 	{
 		auto newClient = std::make_shared<SipClient>(data->getFromNumber(), data->getSource());
-		_onUnregister(std::move(newClient));
+		unregisterClient(std::move(newClient));
 	}
 }
 
@@ -92,19 +84,19 @@ void RequestsHandler::OnSubscribe(std::shared_ptr<SipMessage> data)
 		<< data->getContentLength() << "\r\n"
 		<< "\r\n";
 
-	_onHandled(data->getFromNumber(), std::make_shared<SipMessage>(SipMessage(okResponse.str(), {})));
+	auto response = std::make_shared<SipMessage>(SipMessage(okResponse.str(), data->getSource()));
+	endHandle(data->getFromNumber(), std::move(response));
 }
 
 void RequestsHandler::OnCancel(std::shared_ptr<SipMessage> data)
 {
 	endCall(data->getCallID(), data->getFromNumber(), data->getToNumber(), data->getFromNumber() + " canceled the session.");
-	_onHandled(data->getToNumber(), data);
+	endHandle(data->getToNumber(), data);
 }
 
 void RequestsHandler::onReqTerminated(std::shared_ptr<SipMessage> data)
 {
-	_onHandled(data->getFromNumber(), data);
-
+	endHandle(data->getFromNumber(), data);
 }
 
 void RequestsHandler::OnInvite(std::shared_ptr<SipMessage> data)
@@ -117,43 +109,43 @@ void RequestsHandler::OnInvite(std::shared_ptr<SipMessage> data)
 
 	auto response = data;
 	response->setContact("Contact: <sip:" + client.value()->getNumber() + "@" + _serverIp + ":" + std::to_string(_serverPort) + ";transport=UDP>");
-	_onHandled(data->getToNumber(), response);
+	endHandle(data->getToNumber(), response);
 }
 
 void RequestsHandler::OnTrying(std::shared_ptr<SipMessage> data)
 {
 	setCallState(data->getCallID(), Session::State::Trying);
-	_onHandled(data->getFromNumber(), data);
+	endHandle(data->getFromNumber(), data);
 }
 
 void RequestsHandler::OnRinging(std::shared_ptr<SipMessage> data)
 {
 	setCallState(data->getCallID(), Session::State::Ringing);
-	_onHandled(data->getFromNumber(), data);
+	endHandle(data->getFromNumber(), data);
 }
 
 void RequestsHandler::OnBusy(std::shared_ptr<SipMessage> data)
 {
 	endCall(data->getCallID(), data->getFromNumber(), data->getToNumber(), data->getToNumber() + " is busy");
-	_onHandled(data->getFromNumber(), data);
+	endHandle(data->getFromNumber(), data);
 }
 
 void RequestsHandler::OnUnavailable(std::shared_ptr<SipMessage> data)
 {
 	endCall(data->getCallID(), data->getFromNumber(), data->getToNumber(), data->getToNumber() + " is unavailable");
-	_onHandled(data->getFromNumber(), data);
+	endHandle(data->getFromNumber(), data);
 }
 
 void RequestsHandler::OnBye(std::shared_ptr<SipMessage> data)
 {
 	endCall(data->getCallID(), data->getToNumber(), data->getFromNumber());
-	_onHandled(data->getToNumber(), data);
+	endHandle(data->getToNumber(), data);
 }
 
 void RequestsHandler::OnOk(std::shared_ptr<SipMessage> data)
 {
 	auto session = getSession(data->getCallID());
-	if (session.has_value()) 
+	if (session.has_value())
 	{
 		auto sdpMessage = dynamic_cast<SipSdpMessage*>(data.get());
 		auto client = findClient(data->getToNumber());
@@ -167,12 +159,12 @@ void RequestsHandler::OnOk(std::shared_ptr<SipMessage> data)
 	{
 		response->setContact("Contact: <sip:" + data->getToNumber() + "@" + _serverIp + ":" + std::to_string(_serverPort) + ";transport=UDP>");
 	}
-	_onHandled(data->getFromNumber(), std::move(response));
+	endHandle(data->getFromNumber(), std::move(response));
 }
 
 void RequestsHandler::OnAck(std::shared_ptr<SipMessage> data)
 {
-	_onHandled(data->getToNumber(), data);
+	endHandle(data->getToNumber(), data);
 }
 
 bool RequestsHandler::setCallState(const std::string& callID, Session::State state)
@@ -201,13 +193,44 @@ void RequestsHandler::endCall(const std::string& callID, const std::string& srcN
 	}
 }
 
-std::optional<std::shared_ptr<SipClient>> RequestsHandler::findClient(std::string number)
+bool RequestsHandler::registerClient(std::shared_ptr<SipClient> client)
 {
-	auto it = _clients.find(std::move(number));
+	if (_clients.find(client->getNumber()) == _clients.end()) {
+		std::cout << "New Client: " << client->getNumber() << std::endl;
+		_clients.emplace(client->getNumber(), client);
+		return true;
+	}
+	return false;
+}
+
+void RequestsHandler::unregisterClient(std::shared_ptr<SipClient> client)
+{
+	std::cout << "unregister client: " << client->getNumber() << std::endl;
+	_clients.erase(client->getNumber());
+}
+
+std::optional<std::shared_ptr<SipClient>> RequestsHandler::findClient(const std::string& number)
+{
+	auto it = _clients.find(number);
 	if (it != _clients.end())
 	{
 		return it->second;
 	}
 
 	return {};
+}
+
+void RequestsHandler::endHandle(const std::string& destNumber, std::shared_ptr<SipMessage> message)
+{
+	auto destClient = findClient(destNumber);
+	if (destClient.has_value())
+	{
+		_onHandled(std::move(destClient.value()->getAddress()), std::move(message));
+	}
+	else
+	{
+		message->setHeader(SipMessageTypes::NOT_FOUND);
+		auto src = message->getSource();
+		_onHandled(src, std::move(message));
+	}
 }

--- a/src/SIP/RequestsHandler.cpp
+++ b/src/SIP/RequestsHandler.cpp
@@ -84,7 +84,7 @@ void RequestsHandler::OnSubscribe(std::shared_ptr<SipMessage> data)
 		<< data->getContentLength() << "\r\n"
 		<< "\r\n";
 
-	auto response = std::make_shared<SipMessage>(SipMessage(okResponse.str(), data->getSource()));
+	auto response = std::make_shared<SipMessage>(okResponse.str(), data->getSource());
 	endHandle(data->getFromNumber(), std::move(response));
 }
 

--- a/src/SIP/RequestsHandler.hpp
+++ b/src/SIP/RequestsHandler.hpp
@@ -8,9 +8,9 @@
 #include "SipClient.hpp"
 #include "Session.hpp"
 
-class RequestsHandler 
+class RequestsHandler
 {
-public:	
+public:
 
 	using OnHandledEvent = std::function<void(const sockaddr_in&, std::shared_ptr<SipMessage>)>;
 
@@ -18,7 +18,7 @@ public:
 		OnHandledEvent onHandledEvent);
 
 	void handle(std::shared_ptr<SipMessage> request);
-	
+
 	std::optional<std::shared_ptr<Session>> getSession(const std::string& callID);
 
 private:

--- a/src/SIP/RequestsHandler.hpp
+++ b/src/SIP/RequestsHandler.hpp
@@ -12,12 +12,9 @@ class RequestsHandler
 {
 public:	
 
-	using OnHandledEvent = std::function<void(std::string, std::shared_ptr<SipMessage>)>;
+	using OnHandledEvent = std::function<void(const sockaddr_in&, std::shared_ptr<SipMessage>)>;
 
-	RequestsHandler(std::string serverIp, int serverPort, std::unordered_map<std::string, std::shared_ptr<Session>>& sessions,
-		std::unordered_map<std::string, std::shared_ptr<SipClient>>& clients,
-		std::function<void(std::shared_ptr<SipClient>)> onNewClientEvent,
-		std::function<void(std::shared_ptr<SipClient>)> onUnregisterEvent,
+	RequestsHandler(std::string serverIp, int serverPort,
 		OnHandledEvent onHandledEvent);
 
 	void handle(std::shared_ptr<SipMessage> request);
@@ -43,11 +40,16 @@ private:
 	bool setCallState(const std::string& callID, Session::State state);
 	void endCall(const std::string& callID, const std::string& srcNumber, const std::string& destNumber, const std::string& reason = "");
 
-	std::optional<std::shared_ptr<SipClient>> findClient(std::string number);
+	bool registerClient(std::shared_ptr<SipClient> client);
+	void unregisterClient(std::shared_ptr<SipClient> client);
+
+	std::optional<std::shared_ptr<SipClient>> findClient(const std::string& number);
+
+	void endHandle(const std::string& destNumber, std::shared_ptr<SipMessage> message);
 
 	std::unordered_map<std::string, std::function<void(std::shared_ptr<SipMessage> request)>> _handlers;
-	std::unordered_map<std::string, std::shared_ptr<Session>>& _sessions;
-	std::unordered_map<std::string, std::shared_ptr<SipClient>>& _clients;
+	std::unordered_map<std::string, std::shared_ptr<Session>> _sessions;
+	std::unordered_map<std::string, std::shared_ptr<SipClient>> _clients;
 
 	std::function<void(std::shared_ptr<SipClient>)> _onNewClient;
 	std::function<void(std::shared_ptr<SipClient>)> _onUnregister;

--- a/src/SIP/RequestsHandler.hpp
+++ b/src/SIP/RequestsHandler.hpp
@@ -14,14 +14,15 @@ public:
 
 	using OnHandledEvent = std::function<void(std::string, std::shared_ptr<SipMessage>)>;
 
-	RequestsHandler(std::string serverIp, int serverPort, std::unordered_map<std::string, Session>& sessions, 
-		std::function<void(SipClient)> onNewClientEvent,
-		std::function<void(SipClient)> onUnregisterEvent,
+	RequestsHandler(std::string serverIp, int serverPort, std::unordered_map<std::string, std::shared_ptr<Session>>& sessions,
+		std::unordered_map<std::string, std::shared_ptr<SipClient>>& clients,
+		std::function<void(std::shared_ptr<SipClient>)> onNewClientEvent,
+		std::function<void(std::shared_ptr<SipClient>)> onUnregisterEvent,
 		OnHandledEvent onHandledEvent);
 
 	void handle(std::shared_ptr<SipMessage> request);
 	
-	std::optional<std::reference_wrapper<Session>> getSession(const std::string& callID) const;
+	std::optional<std::shared_ptr<Session>> getSession(const std::string& callID);
 
 private:
 	void initHandlers();
@@ -42,11 +43,14 @@ private:
 	bool setCallState(const std::string& callID, Session::State state);
 	void endCall(const std::string& callID, const std::string& srcNumber, const std::string& destNumber, const std::string& reason = "");
 
-	std::unordered_map<std::string, std::function<void(std::shared_ptr<SipMessage> request)>> _handlers;
-	std::unordered_map<std::string, Session>& _sessions;
+	std::optional<std::shared_ptr<SipClient>> findClient(std::string number);
 
-	std::function<void(SipClient)> _onNewClient;
-	std::function<void(SipClient)> _onUnregister;
+	std::unordered_map<std::string, std::function<void(std::shared_ptr<SipMessage> request)>> _handlers;
+	std::unordered_map<std::string, std::shared_ptr<Session>>& _sessions;
+	std::unordered_map<std::string, std::shared_ptr<SipClient>>& _clients;
+
+	std::function<void(std::shared_ptr<SipClient>)> _onNewClient;
+	std::function<void(std::shared_ptr<SipClient>)> _onUnregister;
 	OnHandledEvent _onHandled;
 
 	std::string _serverIp;

--- a/src/SIP/Session.cpp
+++ b/src/SIP/Session.cpp
@@ -1,6 +1,6 @@
 #include "Session.hpp"
 
-Session::Session(std::string callID, std::shared_ptr<SipClient> src, size_t srcRtpPort) :
+Session::Session(std::string callID, std::shared_ptr<SipClient> src, uint32_t srcRtpPort) :
 	_callID(std::move(callID)), _src(src), _state(State::Invited), _srcRtpPort(srcRtpPort), _destRtpPort(0)
 {
 }
@@ -17,7 +17,7 @@ void Session::setState(State state)
 	}
 }
 
-void Session::setDest(std::shared_ptr<SipClient> dest, size_t destRtpPort)
+void Session::setDest(std::shared_ptr<SipClient> dest, uint32_t destRtpPort)
 {
 	_dest = dest;
 	_destRtpPort = destRtpPort;

--- a/src/SIP/Session.cpp
+++ b/src/SIP/Session.cpp
@@ -1,6 +1,6 @@
 #include "Session.hpp"
 
-Session::Session(std::string callID, SipClient src, size_t srcRtpPort) :
+Session::Session(std::string callID, std::shared_ptr<SipClient> src, size_t srcRtpPort) :
 	_callID(std::move(callID)), _src(src), _state(State::Invited), _srcRtpPort(srcRtpPort), _destRtpPort(0)
 {
 }
@@ -13,11 +13,11 @@ void Session::setState(State state)
 	std::cout << "New Session state: " << static_cast<int>(_state) << std::endl;
 	if (state == State::Connected)
 	{
-		std::cout << "Session Created between " << _src.getNumber() << " and " << _dest.getNumber() << std::endl;		
+		std::cout << "Session Created between " << _src->getNumber() << " and " << _dest->getNumber() << std::endl;
 	}
 }
 
-void Session::setDest(SipClient dest, size_t destRtpPort)
+void Session::setDest(std::shared_ptr<SipClient> dest, size_t destRtpPort)
 {
 	_dest = dest;
 	_destRtpPort = destRtpPort;
@@ -28,12 +28,12 @@ std::string Session::getCallID() const
 	return _callID;
 }
 
-SipClient Session::getSrc() const
+std::shared_ptr<SipClient> Session::getSrc() const
 {
 	return _src;
 }
 
-SipClient Session::getDest() const
+std::shared_ptr<SipClient> Session::getDest() const
 {
 	return _dest;
 }

--- a/src/SIP/Session.hpp
+++ b/src/SIP/Session.hpp
@@ -18,7 +18,7 @@ public:
 
 
 	Session(std::string callID, std::shared_ptr<SipClient> src, uint32_t srcRtpPort);
-	
+
 	void setState(State state);
 	void setDest(std::shared_ptr<SipClient> dest, uint32_t destRtpPort);
 

--- a/src/SIP/Session.hpp
+++ b/src/SIP/Session.hpp
@@ -17,10 +17,10 @@ public:
 	};
 
 
-	Session(std::string callID, std::shared_ptr<SipClient> src, size_t srcRtpPort);
+	Session(std::string callID, std::shared_ptr<SipClient> src, uint32_t srcRtpPort);
 	
 	void setState(State state);
-	void setDest(std::shared_ptr<SipClient> dest, size_t destRtpPort);
+	void setDest(std::shared_ptr<SipClient> dest, uint32_t destRtpPort);
 
 	std::string getCallID() const;
 	std::shared_ptr<SipClient> getSrc() const;
@@ -32,8 +32,8 @@ private:
 	std::shared_ptr<SipClient> _dest;
 	State _state;
 
-	int _srcRtpPort;
-	int _destRtpPort;	
+	uint32_t _srcRtpPort;
+	uint32_t _destRtpPort;
 };
 
 #endif

--- a/src/SIP/Session.hpp
+++ b/src/SIP/Session.hpp
@@ -17,19 +17,19 @@ public:
 	};
 
 
-	Session(std::string callID, SipClient src, size_t srcRtpPort);
+	Session(std::string callID, std::shared_ptr<SipClient> src, size_t srcRtpPort);
 	
 	void setState(State state);
-	void setDest(SipClient dest, size_t destRtpPort);
+	void setDest(std::shared_ptr<SipClient> dest, size_t destRtpPort);
 
 	std::string getCallID() const;
-	SipClient getSrc() const;
-	SipClient getDest() const;
+	std::shared_ptr<SipClient> getSrc() const;
+	std::shared_ptr<SipClient> getDest() const;
 
 private:
 	std::string _callID;
-	SipClient _src;
-	SipClient _dest;
+	std::shared_ptr<SipClient> _src;
+	std::shared_ptr<SipClient> _dest;
 	State _state;
 
 	int _srcRtpPort;

--- a/src/SIP/SipClient.hpp
+++ b/src/SIP/SipClient.hpp
@@ -7,15 +7,12 @@
 class SipClient
 {
 public:
-	SipClient() = default;
 	SipClient(std::string number, sockaddr_in address);
-
 
 	bool operator==(SipClient other);
 
 	std::string getNumber() const;
 	sockaddr_in getAddress() const;
-
 
 private:
 	std::string _number;

--- a/src/SIP/SipMessage.cpp
+++ b/src/SIP/SipMessage.cpp
@@ -12,7 +12,7 @@ SipMessage::SipMessage(std::string message, sockaddr_in src) : _messageStr(std::
 void SipMessage::parse()
 {
 	std::string msg = _messageStr;
-	
+
 	size_t pos = msg.find(SipMessageHeaders::HEADERS_DELIMETER);
 	_header = msg.substr(0, pos);
 	msg.erase(0, pos + strlen(SipMessageHeaders::HEADERS_DELIMETER));
@@ -68,12 +68,12 @@ void SipMessage::parse()
 
 bool SipMessage::isValidMessage() const
 {
-	if (_via.empty() || _to.empty() || _from.empty() || _callID.empty() || _cSeq.empty()) 
+	if (_via.empty() || _to.empty() || _from.empty() || _callID.empty() || _cSeq.empty())
 	{
 		return false;
 	}
 
-	if ((_type == SipMessageTypes::INVITE || _type == SipMessageTypes::REGISTER) && _contact.empty()) 
+	if ((_type == SipMessageTypes::INVITE || _type == SipMessageTypes::REGISTER) && _contact.empty())
 	{
 		return false;
 	}

--- a/src/SIP/SipMessage.hpp
+++ b/src/SIP/SipMessage.hpp
@@ -7,7 +7,7 @@
 class SipMessage
 {
 public:
-	
+
 	SipMessage(std::string message, sockaddr_in src);
 
 	void setType(std::string value);

--- a/src/SIP/SipSdpMessage.cpp
+++ b/src/SIP/SipSdpMessage.cpp
@@ -18,7 +18,7 @@ void SipSdpMessage::setRtpPort(int port)
 {
 	std::string currentRtpPort = std::to_string(_rtpPort);
 	std::string copyM = _media;
-	copyM.replace(_media.find(currentRtpPort), currentRtpPort.length() ,std::to_string(port));
+	copyM.replace(_media.find(currentRtpPort), currentRtpPort.length(), std::to_string(port));
 	_rtpPort = port;
 	setMedia(std::move(copyM));
 }

--- a/src/SIP/SipSdpMessage.hpp
+++ b/src/SIP/SipSdpMessage.hpp
@@ -18,7 +18,6 @@ public:
 	std::string getTime() const;
 	std::string getMedia() const;
 	int getRtpPort() const;
-	
 
 private:
 	void parse() override;

--- a/src/SIP/SipServer.cpp
+++ b/src/SIP/SipServer.cpp
@@ -3,10 +3,7 @@
 
 SipServer::SipServer(std::string ip, int port) :
 	_socket(ip, port, std::bind(&SipServer::onNewMessage, this, std::placeholders::_1, std::placeholders::_2)),
-	_handler(ip, port, _sessions,_clients, 
-		std::bind(&SipServer::onNewClient, this, std::placeholders::_1), 
-		std::bind(&SipServer::onUnregister, this, std::placeholders::_1), 
-		std::bind(&SipServer::onHandled, this, std::placeholders::_1, std::placeholders::_2))
+	_handler(ip, port, std::bind(&SipServer::onHandled, this, std::placeholders::_1, std::placeholders::_2))
 {
 	_socket.startReceive();
 }
@@ -14,36 +11,13 @@ SipServer::SipServer(std::string ip, int port) :
 void SipServer::onNewMessage(std::string data, sockaddr_in src)
 {
 	auto message = _messagesFactory.createMessage(std::move(data), std::move(src));
-	if (message.has_value()) 
+	if (message.has_value())
 	{
 		_handler.handle(std::move(message.value()));
 	}
 }
 
-void SipServer::onNewClient(std::shared_ptr<SipClient> newClient)
+void SipServer::onHandled(const sockaddr_in& dest, std::shared_ptr<SipMessage> message)
 {
-	if (_clients.find(newClient->getNumber()) == _clients.end()) {
-		std::cout << "New Client: " << newClient->getNumber() << std::endl;
-		_clients.emplace(newClient->getNumber(), newClient);
-	}		
-}
-
-void SipServer::onUnregister(std::shared_ptr<SipClient> client)
-{
-	std::cout << "unregister client: " << client->getNumber() << std::endl;
-	_clients.erase(client->getNumber());
-}
-
-void SipServer::onHandled(std::string destNumber, std::shared_ptr<SipMessage> message)
-{
-	try
-	{
-		_socket.send(_clients.at(std::move(destNumber))->getAddress(), message->toString());
-	}
-	catch (const std::out_of_range&)
-	{
-		SipMessage messagae(*message);
-		messagae.setHeader(SipMessageTypes::NOT_FOUND);
-		_socket.send(message->getSource(),std::move(messagae.toString()));
-	}
+	_socket.send(dest, message->toString());
 }

--- a/src/SIP/SipServer.hpp
+++ b/src/SIP/SipServer.hpp
@@ -13,14 +13,14 @@ public:
 
 private:
 	void onNewMessage(std::string data, sockaddr_in src);
-	void onNewClient(SipClient newClient);
-	void onUnregister(SipClient client);
+	void onNewClient(std::shared_ptr<SipClient> newClient);
+	void onUnregister(std::shared_ptr<SipClient> client);
 	void onHandled(std::string destNumber, std::shared_ptr<SipMessage> message);
 
 	UdpServer _socket;
 	RequestsHandler _handler;
 	SipMessageFactory _messagesFactory;
-	std::unordered_map<std::string, SipClient> _clients;
-	std::unordered_map<std::string, Session> _sessions;
+	std::unordered_map<std::string, std::shared_ptr<SipClient>> _clients;
+	std::unordered_map<std::string, std::shared_ptr<Session>> _sessions;
 };
 #endif

--- a/src/SIP/SipServer.hpp
+++ b/src/SIP/SipServer.hpp
@@ -13,14 +13,10 @@ public:
 
 private:
 	void onNewMessage(std::string data, sockaddr_in src);
-	void onNewClient(std::shared_ptr<SipClient> newClient);
-	void onUnregister(std::shared_ptr<SipClient> client);
-	void onHandled(std::string destNumber, std::shared_ptr<SipMessage> message);
+	void onHandled(const sockaddr_in& dest, std::shared_ptr<SipMessage> message);
 
 	UdpServer _socket;
 	RequestsHandler _handler;
 	SipMessageFactory _messagesFactory;
-	std::unordered_map<std::string, std::shared_ptr<SipClient>> _clients;
-	std::unordered_map<std::string, std::shared_ptr<Session>> _sessions;
 };
 #endif


### PR DESCRIPTION
This pull request reduce the copy of SipClient class over and over again throught the program running.
In addition, the sessions and clients properties removed from SipServer.