### PR TITLE
Include <memory> in Session.hpp for Linux build

### DIFF
--- a/src/SIP/Session.hpp
+++ b/src/SIP/Session.hpp
@@ -1,6 +1,8 @@
 #ifndef SESSION_HPP
 #define SESSION_HPP
 
+#include <memory>
+
 #include "SipClient.hpp"
 #include "UdpServer.hpp"
 


### PR DESCRIPTION
To get this project to build on Ubuntu 22.04 with gcc 11 I need to include &lt;memory&gt; here for std::shared_ptr. Hope this makes sense - I haven't done any C++ for over 25 years!