### PR TITLE
Update UdpServer.cpp

### DIFF
--- a/src/Helpers/UdpServer.cpp
+++ b/src/Helpers/UdpServer.cpp
@@ -50,6 +50,7 @@ void UdpServer::startReceive()
 
 			while (_keepRunning)
 			{
+				std::memset(&senderEndPoint, 0, sizeof(senderEndPoint));
 #ifdef __linux__
 				recvfrom(_sockfd, buffer, BUFFER_SIZE, 0, reinterpret_cast<struct sockaddr*>(&senderEndPoint), (socklen_t*)&len);
 #elif defined _WIN32 || defined _WIN64


### PR DESCRIPTION
Needed to add memset statement as first statement in while loop to zero out buffer prior to reading in new data. This fixes a bug whereby if a long message is followed by a shorter message on Ubuntu under WSL2 on Windows that then the message read from the socket is not "\0" terminated and therefore the end of the previous message remains in the buffer - this causes SIP transactions to fail in the clients.