### PR TITLE
UDBServer.cpp line10 #ifdef replacement

### DIFF
--- a/src/Helpers/UdpServer.cpp
+++ b/src/Helpers/UdpServer.cpp
@@ -7,7 +7,7 @@
 UdpServer::UdpServer(std::string ip, int port, OnNewMessageEvent event) : _ip(std::move(ip)), _port(port), _onNewMessageEvent(event), _keepRunning(false)
 {
 
-#ifdef _WIN32 || defined _WIN64
+#if defined _WIN32 || _WIN64
 	WSADATA wsa;
 	if (WSAStartup(MAKEWORD(2, 2), &wsa) != 0)
 	{

--- a/src/Helpers/UdpServer.cpp
+++ b/src/Helpers/UdpServer.cpp
@@ -7,7 +7,7 @@
 UdpServer::UdpServer(std::string ip, int port, OnNewMessageEvent event) : _ip(std::move(ip)), _port(port), _onNewMessageEvent(event), _keepRunning(false)
 {
 
-#if defined _WIN32 || _WIN64
+#if defined _WIN32 || defined _WIN64
 	WSADATA wsa;
 	if (WSAStartup(MAKEWORD(2, 2), &wsa) != 0)
 	{


### PR DESCRIPTION
BarGabriel,
Hi - I was recompiling my copy of SipServer and decided to investigate the warning I was getting when compiling UDBServer on WSL2 with g++. The warning is that the original #fdef _WIN32 || defined _WIN64 had extra characters after ||. I tested this with the following simple program.

#include <stdio.h>

#define a

int main(int argc, char** argv)
{

#ifdef a || defined b
printf("defined\n");
#endif

printf("hello world\n");
}

The warning is

qt.c: In function ‘main’:
qt.c:8:10: warning: extra tokens at end of #ifdef directive
    8 | #ifdef a || defined b
      |

if you define a the code runs properly. However if you define b instead the first printf doesn't get executed.

The correct pre-processor command is

#if defined a || defined b.

That's what this patch implements in udpserver.cpp

Hope This helps